### PR TITLE
Update multi-post-thumbnails.php

### DIFF
--- a/multi-post-thumbnails.php
+++ b/multi-post-thumbnails.php
@@ -178,11 +178,11 @@ if (!class_exists('MultiPostThumbnails')) {
 
 			if (version_compare($wp_version, '3.5', '<')) {	
 				add_thickbox();
-				wp_enqueue_script( "mpt-featured-image", $this->plugins_url( 'js/multi-post-thumbnails-admin.js', __FILE__ ), array( 'jquery', 'media-upload' ) );
+				wp_enqueue_script( "mpt-featured-image", plugins_url() . '/' . basename(dirname(__FILE__)) . '/js/multi-post-thumbnails-admin.js', array( 'jquery', 'media-upload' ) );
 			} else { // 3.5+ media modal
 				wp_enqueue_media();
-				wp_enqueue_script( "mpt-featured-image", $this->plugins_url( 'js/multi-post-thumbnails-admin.js', __FILE__ ), array( 'jquery', 'set-post-thumbnail' ) );
-				wp_enqueue_script( "mpt-featured-image-modal", $this->plugins_url( 'js/media-modal.js', __FILE__ ), array( 'jquery', 'media-models' ) );				
+				wp_enqueue_script( "mpt-featured-image", plugins_url() . '/' . basename(dirname(__FILE__)) . '/js/multi-post-thumbnails-admin.js', array( 'jquery', 'set-post-thumbnail' ) );
+				wp_enqueue_script( "mpt-featured-image-modal", plugins_url() . '/' . basename(dirname(__FILE__)) . '/js/media-modal.js', array( 'jquery', 'media-models' ) );
 			}
 		}
 		


### PR DESCRIPTION
Hi Team - 

For various deployment reasons, we're required to have an approved set of plugins and symlink them into our WP directory.  There's a bug in the plugin that forces it to resolve the directory of the symlinked plugin, rather than the wp content directory.  This fixes it.

For reference, here's what the generated links looked like before:
    
    http://localhost/~brian/firebird-wordpress/wp/wp-content/plugins/Users/brian/code/wbie/firebird-wordpress/wp-content/plugins/multiple-post-thumbnails/js/media-modal.js?ver=3.6.1

And here's after:

    http://localhost/~brian/firebird-wordpress/wp/wp-content/plugins/multiple-post-thumbnails/js/media-modal.js?ver=3.6.1

Also note, there might be a better way to do this, I'm not WP pro :)