### PR TITLE
use max-width instead of width for mpt in admin metabox to prevent small...

### DIFF
--- a/css/multi-post-thumbnails-admin.css
+++ b/css/multi-post-thumbnails-admin.css
@@ -1,4 +1,4 @@
 img.mpt-thumbnail {
-  width: 100%;
+  max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
... images from being upscaled. Fixes (for real this time) #44.