### PR TITLE
Fix attachment selection bug

### DIFF
--- a/js/media-modal.js
+++ b/js/media-modal.js
@@ -23,20 +23,14 @@ var MediaModal = function (options) {
       },
       library : {
         type : 'image'
-      }
+      },
+      multiple: false
     });
-		
+
     // Set filterable state to uploaded to get select to show (setting this
     // when creating the frame doesn't work)
     frame.on('toolbar:create:select', function(){
       frame.state().set('filterable', 'uploaded');
-    });
-
-    // When an image is selected, run the callback.
-    frame.on('select', function () {
-      // We set multiple to false so only get one image from the uploader
-      var attachment = frame.state().get('selection').first().toJSON();
-      that.settings.cb(attachment);
     });
 
     frame.on('open activate', function() {
@@ -50,7 +44,7 @@ var MediaModal = function (options) {
         selection.add(Attachment.get($caller.data('thumbnail_id')));
       }
     });
-        
+
     frame.open();
   };
 

--- a/js/media-modal.js
+++ b/js/media-modal.js
@@ -33,15 +33,34 @@ var MediaModal = function (options) {
       frame.state().set('filterable', 'uploaded');
     });
 
-    frame.on('open activate', function() {
+    frame.on( 'open', function() {
       // Get the link/button/etc that called us
-      var $caller = jQuery(that.settings.calling_selector);
+      var $caller = jQuery( that.settings.calling_selector );
 
       // Select the thumbnail if we have one
-      if ($caller.data('thumbnail_id')) {
-        var Attachment = wp.media.model.Attachment;
-        var selection = frame.state().get('selection');
-        selection.add(Attachment.get($caller.data('thumbnail_id')));
+      if ( $caller.data( 'thumbnail_id' ) ) {
+        var Attachment  = wp.media.model.Attachment.get( $caller.data( 'thumbnail_id' ) );
+        Attachment.fetch();
+        var selection = frame.state().get( 'selection' );
+        selection.add( Attachment );
+
+        // Overload the library's comparator to push items that are not in
+        // the mirrored query to the front of the aggregate collection.
+        var library = frame.state().get( 'library' );
+        var comparator = library.comparator;
+        library.comparator = function( a, b ) {
+          var aInQuery = !! this.mirroring.get( a.cid ),
+          bInQuery = !! this.mirroring.get( b.cid );
+
+          if ( ! aInQuery && bInQuery ) {
+            return -1;
+          }  else if ( aInQuery && ! bInQuery ) {
+          return 1;
+          }  else {
+          return comparator.apply( this, arguments );
+          }
+        };
+        library.observe( selection );
       }
     });
 


### PR DESCRIPTION
I've been using Multiple Post Thumbnails v1.6.5 on a project involving a large media library (1500+ attachments) and have run into a bug where the details frequently fail to populate for a selected attachment when opening the MediaModal.  After investigating, I determined that this occurs because a selected attachment is added to the frame's selection, but not explicitly fetched.  If the selected attachment is included in the initial query-attachments call(s), details populate.  If the attachment is not included, details remain blank until the attachment is loaded via a subsequent call.

This fix takes inspiration from the WordPress featured image uploader by explicitly fetching the selected attachment and then modifying the library's comparator so that a selected attachment shows before any other attachments.  I also removed some redundant event handling by specifying multiple: false on frame creation and by adding a selected attachment only on frame open instead of open / activate.