### PR TITLE
Consider adding hooks for set/delete thumbnails.

### DIFF
--- a/multi-post-thumbnails.php
+++ b/multi-post-thumbnails.php
@@ -450,6 +450,7 @@ if (!class_exists('MultiPostThumbnails')) {
 
 			if ($thumbnail_id == '-1') {
 				delete_post_meta($post_ID, $this->get_meta_key());
+				do_action( "delete_multi_thumbnail_{$this->id}", $post_ID );
 				die($this->post_thumbnail_html(null));
 			}
 

--- a/multi-post-thumbnails.php
+++ b/multi-post-thumbnails.php
@@ -457,6 +457,7 @@ if (!class_exists('MultiPostThumbnails')) {
 				$thumbnail_html = wp_get_attachment_image($thumbnail_id, 'thumbnail');
 				if (!empty($thumbnail_html)) {
 					$this->set_meta($post_ID, $this->post_type, $this->id, $thumbnail_id);
+					do_action( "set_multi_thumbnail_{$this->id}", $post_ID, $thumbnail_id );
 					die($this->post_thumbnail_html($thumbnail_id));
 				}
 			}


### PR DESCRIPTION
Hi

It would be useful to have something to hook into when a thumbnail is set/deleted.

I'm attempting to sync the setting of thumbnails in the WPML multi-language plugin and it would be handy to be able to set/delete thumbnails for translations when they are updated.

The pull request assumes using filters that include the thumbnail type ID:

`delete_multi_thumbnail_{type_id}`
`set_multi_thumbnail_{type_id}`

... and passing the `$post_ID` as a parameter, and `$thumbnail_id` as another parameter when setting an image.

Potentially having a more generic filter like `delete_multi_thumbnail` and passing `$type_id` as another parameter could work instead.

Ben