### PR TITLE
Remove calls to get thumbnail post.

### DIFF
--- a/multi-post-thumbnails.php
+++ b/multi-post-thumbnails.php
@@ -408,7 +408,7 @@ if (!class_exists('MultiPostThumbnails')) {
 			$set_thumbnail_link = sprintf( $format_string, sprintf( esc_attr__( "Set %s" , 'multiple-post-thumbnails' ), $this->label ), esc_url($image_library_url), $this->post_type, $this->id, $url_class, $this->label, $thumbnail_id );
 			$content = sprintf( $set_thumbnail_link, sprintf( esc_html__( "Set %s", 'multiple-post-thumbnails' ), $this->label ) );
 
-			if ($thumbnail_id && get_post($thumbnail_id)) {
+			if ($thumbnail_id) {
 				$old_content_width = $content_width;
 				$content_width = 266;
 				$attr = array( 'class' => 'mpt-thumbnail' );
@@ -453,7 +453,7 @@ if (!class_exists('MultiPostThumbnails')) {
 				die($this->post_thumbnail_html(null));
 			}
 
-			if ($thumbnail_id && get_post($thumbnail_id)) {
+			if ($thumbnail_id) {
 				$thumbnail_html = wp_get_attachment_image($thumbnail_id, 'thumbnail');
 				if (!empty($thumbnail_html)) {
 					$this->set_meta($post_ID, $this->post_type, $this->id, $thumbnail_id);


### PR DESCRIPTION
When using this plugin with
https://github.com/humanmade/network-media-library it doesn't work, it
seems this is because it attempts to retrieve the post of the thumbnail
(needlessly afaict) which won't work because the image exists on a
different site in the network.

Removing these calls seems to fix the issue and allows for a better
mutli site experience. I'm not sure of any adverse affects of this, but
let me know if you can see one.