### PR TITLE
Use wp.i18n for localization in multi-post-thumbnails-admin.js

### DIFF
--- a/js/multi-post-thumbnails-admin.js
+++ b/js/multi-post-thumbnails-admin.js
@@ -16,7 +16,7 @@ window.MultiPostThumbnails = {
 		    action:'set-' + post_type + '-' + id + '-thumbnail', post_id: jQuery('#post_ID').val(), thumbnail_id: -1, _ajax_nonce: nonce, cookie: encodeURIComponent(document.cookie)
 	    }, function(str){
 		    if ( str == '0' ) {
-			    alert( setPostThumbnailL10n.error );
+			    alert( wp.i18n.__( 'Could not remove the image.' )  );
 		    } else {
 			    MultiPostThumbnails.setThumbnailHTML(str, id, post_type);
 		    }
@@ -28,17 +28,17 @@ window.MultiPostThumbnails = {
     setAsThumbnail: function(thumb_id, id, post_type, nonce){
 	    var $link = jQuery('a#' + post_type + '-' + id + '-thumbnail-' + thumb_id);
 		$link.data('thumbnail_id', thumb_id);
-	    $link.text( setPostThumbnailL10n.saving );
+	    $link.text( wp.i18n.__( 'Saving...' )  );
 	    jQuery.post(ajaxurl, {
 		    action:'set-' + post_type + '-' + id + '-thumbnail', post_id: post_id, thumbnail_id: thumb_id, _ajax_nonce: nonce, cookie: encodeURIComponent(document.cookie)
 	    }, function(str){
 		    var win = window.dialogArguments || opener || parent || top;
-		    $link.text( setPostThumbnailL10n.setThumbnail );
+		    $link.text( wp.i18n.__( 'Use as title image' ) );
 		    if ( str == '0' ) {
-			    alert( setPostThumbnailL10n.error );
+			    alert( wp.i18n.__( 'Could not set that image. Try a different attachment.' )  );
 		    } else {
 			    $link.show();
-			    $link.text( setPostThumbnailL10n.done );
+			    $link.text( wp.i18n.__( 'Done' )  );
 			    $link.fadeOut( 2000, function() {
 				    jQuery('tr.' + post_type + '-' + id + '-thumbnail').hide();
 			    });


### PR DESCRIPTION
### What does this PR do?
Uses wp.i18n for localization in admin metaboxes because `setPostThumbnailL10n` was removed from WordPress 5.5.

### Why are we doing this?
The plugin began producing JavaScript errors with the 5.5 update.

### References
- https://make.wordpress.org/core/2020/08/05/more-support-for-javascript-i18n-in-wordpress-5-5/
- https://make.wordpress.org/core/2018/11/09/new-javascript-i18n-support-in-wordpress/
- https://developer.wordpress.org/block-editor/packages/packages-i18n/
- https://core.trac.wordpress.org/ticket/50605


