### PR TITLE
Moved all setPostThumbnailL10n string calls to wp.i18n calls to match…

### DIFF
--- a/js/multi-post-thumbnails-admin.js
+++ b/js/multi-post-thumbnails-admin.js
@@ -16,7 +16,7 @@ window.MultiPostThumbnails = {
 		    action:'set-' + post_type + '-' + id + '-thumbnail', post_id: jQuery('#post_ID').val(), thumbnail_id: -1, _ajax_nonce: nonce, cookie: encodeURIComponent(document.cookie)
 	    }, function(str){
 		    if ( str == '0' ) {
-			    alert( setPostThumbnailL10n.error );
+			    alert( wp.i18n.__( 'Could not set that as the thumbnail image. Try a different attachment.' ) );
 		    } else {
 			    MultiPostThumbnails.setThumbnailHTML(str, id, post_type);
 		    }
@@ -28,17 +28,17 @@ window.MultiPostThumbnails = {
     setAsThumbnail: function(thumb_id, id, post_type, nonce){
 	    var $link = jQuery('a#' + post_type + '-' + id + '-thumbnail-' + thumb_id);
 		$link.data('thumbnail_id', thumb_id);
-	    $link.text( setPostThumbnailL10n.saving );
+	    $link.text( wp.i18n.__( 'Saving…' ) );
 	    jQuery.post(ajaxurl, {
 		    action:'set-' + post_type + '-' + id + '-thumbnail', post_id: post_id, thumbnail_id: thumb_id, _ajax_nonce: nonce, cookie: encodeURIComponent(document.cookie)
 	    }, function(str){
 		    var win = window.dialogArguments || opener || parent || top;
-		    $link.text( setPostThumbnailL10n.setThumbnail );
+		    $link.text( wp.i18n.__( 'Use as featured image' ) );
 		    if ( str == '0' ) {
-			    alert( setPostThumbnailL10n.error );
+			    alert( wp.i18n.__( 'Could not set that as the thumbnail image. Try a different attachment.' ) );
 		    } else {
 			    $link.show();
-			    $link.text( setPostThumbnailL10n.done );
+			    $link.text( wp.i18n.__( 'Done' ) );
 			    $link.fadeOut( 2000, function() {
 				    jQuery('tr.' + post_type + '-' + id + '-thumbnail').hide();
 			    });


### PR DESCRIPTION
This works but it needs to be reviewed by the plugin author as I do not have any deep knowledge of the changes made. As mentioned in #146 it looks like Wordpress changed the method of accessing strings that was used by this plugin. I took what Wordpress core used for these messages in `set-post-thumbnail.js` and used them in the plugin.

… what's found in WordPress 5.5. core updates:

https://github.com/WordPress/WordPress/commit/4377e9a44e2c10ac66cb9cc49a4a3c8dff6a433f#diff-4bfa11da57ff2600004bb500368247f4